### PR TITLE
add more support for read operations around tags

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -34,6 +34,8 @@ func decodeCommand(buf []byte) (command, error) {
 		return decodePowerStateCommand(ph, buf[HeaderLen:])
 	case PktTags:
 		return decodeTagsCommand(ph, buf[HeaderLen:])
+	case PktTagLabels:
+		return decodeTagLabelsCommand(ph, buf[HeaderLen:])
 	}
 
 	return nil, errors.New(fmt.Sprintf("Unrecognised type 0x%x", ph.PacketType))
@@ -315,15 +317,62 @@ func newGetTagsCommand(site [6]byte) *getTagsCommand {
 // TagsCommand 0x1c
 type tagsCommand struct {
 	commandPacket
+	Payload struct {
+		Tags uint64
+	}
 }
 
 func decodeTagsCommand(ph *packetHeader, payload []byte) (*tagsCommand, error) {
-
 	cmd := &tagsCommand{}
 	cmd.Header = ph
 
 	// decode payload
 	//log.Printf("payload len : %d", len(payload))
+	decodePayload(payload, &cmd.Payload)
+
+	//log.Printf("Command: \n %s", spew.Sdump(cmd))
+
+	return cmd, nil
+}
+
+// GetTagLabelsCommand 0x1d
+type getTagLabelsCommand struct {
+	commandPacket
+	Payload struct {
+		Tags uint64
+	}
+}
+
+func newGetTagLabelsCommand(site [6]byte, tags uint64) *getTagLabelsCommand {
+	ph := newPacketHeader(PktGetTagLabels)
+	ph.Protocol = 0x1400
+	ph.Site = site
+
+	cmd := &getTagLabelsCommand{}
+	cmd.Header = ph
+	cmd.Payload = struct{ Tags uint64 }{Tags: tags}
+
+	return cmd
+}
+
+// TagLabelsCommand 0x1f
+type tagLabelsCommand struct {
+	commandPacket
+	Payload struct {
+		Tags  uint64
+		Label [32]byte
+	}
+}
+
+func decodeTagLabelsCommand(ph *packetHeader, payload []byte) (*tagLabelsCommand, error) {
+	cmd := &tagLabelsCommand{}
+	cmd.Header = ph
+
+	// decode payload
+	//log.Printf("payload len : %d", len(payload))
+	decodePayload(payload, &cmd.Payload)
+
+	//log.Printf("Command: \n %s", spew.Sdump(cmd))
 
 	return cmd, nil
 }

--- a/packet.go
+++ b/packet.go
@@ -31,6 +31,10 @@ const (
 	PktGetTags uint16 = 0x001a
 	PktSetTags uint16 = 0x001b
 	PktTags    uint16 = 0x001c
+
+	PktGetTagLabels uint16 = 0x001d
+	PktSetTagLabels uint16 = 0x001e
+	PktTagLabels    uint16 = 0x001f
 )
 
 type packetHeader struct {


### PR DESCRIPTION
This adds more features around LIFX tags. In particular, it adds the ability to obtain all known tags within the cluster.

This works by adding additional packet decoders, and update triggers within `processCommandEvent()`. Using a mutex, the tags map is then kept up to date by automatically pulling labels whenever a tagsCommand packet is seen.

The data structure is `map[uint64][]byte`. The `uint64` being the tag's ID, and the byte slice being the label name.