### PR TITLE
fix a bunch of style nits

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -3,7 +3,6 @@ package lifx
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -15,7 +14,6 @@ type command interface {
 }
 
 func decodeCommand(buf []byte) (command, error) {
-
 	// read and validate the packet header
 	ph, err := decodePacketHeader(buf)
 
@@ -36,7 +34,7 @@ func decodeCommand(buf []byte) (command, error) {
 		return decodeTagsCommand(ph, buf[HeaderLen:])
 	}
 
-	return nil, errors.New(fmt.Sprintf("Unrecognised type 0x%x", ph.PacketType))
+	return nil, fmt.Errorf("Unrecognised type 0x%x", ph.PacketType)
 }
 
 type commandPacket struct {
@@ -219,7 +217,6 @@ func newSetLightColour(hue uint16, sat uint16, lum uint16, kelvin uint16, timing
 }
 
 func (c *setLightColour) WriteTo(wr io.Writer) (int, error) {
-
 	buf := new(bytes.Buffer)
 
 	err := binary.Write(buf, binary.LittleEndian, &c.Payload)
@@ -269,7 +266,6 @@ func newSetPowerStateCommand(onoff uint16) *setPowerStateCommand {
 }
 
 func (c *setPowerStateCommand) WriteTo(wr io.Writer) (int, error) {
-
 	buf := []byte{0x0, 0x0}
 
 	binary.BigEndian.PutUint16(buf, c.Payload.OnOff)
@@ -318,7 +314,6 @@ type tagsCommand struct {
 }
 
 func decodeTagsCommand(ph *packetHeader, payload []byte) (*tagsCommand, error) {
-
 	cmd := &tagsCommand{}
 	cmd.Header = ph
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestGetPANGatewayCommandWrite(t *testing.T) {
-
 	buf := new(bytes.Buffer)
 
 	c := newGetPANGatewayCommand()
@@ -29,7 +28,6 @@ func TestGetPANGatewayCommandWrite(t *testing.T) {
 }
 
 func TestPANGatewayCommandDecode(t *testing.T) {
-
 	buf := panGatewayMsg()
 
 	cmd, err := decodeCommand(buf)
@@ -56,7 +54,6 @@ func TestPANGatewayCommandDecode(t *testing.T) {
 }
 
 func TestSetPowerStateCommandWrite(t *testing.T) {
-
 	buf := new(bytes.Buffer)
 	addr := [6]byte{0xd0, 0x73, 0xd5, 0x00, 0x35, 0xf7}
 	//	site := [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
@@ -83,7 +80,6 @@ func TestSetPowerStateCommandWrite(t *testing.T) {
 }
 
 func TestPowerStateCommandDecode(t *testing.T) {
-
 	buf := powerStateMsg()
 
 	cmd, err := decodeCommand(buf)

--- a/packet.go
+++ b/packet.go
@@ -71,7 +71,6 @@ func decodePacketHeader(buf []byte) (*packetHeader, error) {
 }
 
 func (p *packetHeader) Encode(wr io.Writer) (int, error) {
-
 	buf := new(bytes.Buffer)
 
 	err := binary.Write(buf, binary.LittleEndian, p)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,4 @@
 package lifx
 
+// Version is the lifx version string
 const Version = "1.1.0"


### PR DESCRIPTION
I'm not sure if these were intentional, but there are things in here that didn't follow a consistent pattern or are not best practices (using `errors.New(fmt.Sprintf())`).

I'm not looking to assert/force any specific style. I figured I'd open this to see if you wanted it merged in. If not, please feel free to close. Likewise, if there are any adjustments you'd like made please let me know.